### PR TITLE
Fix build for tmp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "karma start test/karma.conf.js"
   },
   "dependencies": {
+    "tmp": "0.0.23",
     "brunch": "1.7.13",
     "javascript-brunch": "1.5",
     "coffee-script-brunch": "1.5",


### PR DESCRIPTION
Fix build issue when installing bower:
**Arguments to path.join must be strings**

It is due to an issue with the tmp package version 0.0.24